### PR TITLE
Add blockinput technique

### DIFF
--- a/techniques/blockinput/blockinput.md
+++ b/techniques/blockinput/blockinput.md
@@ -1,0 +1,21 @@
+# *BlockInput*
+
+## Authorship information
+* Name or nickname (required): *Serhii*
+* Twitter: https://twitter.com/semelnyk
+* Linkedin: https://www.linkedin.com/in/serhii-melnyk
+* Email: serhiimelnyk@outlook.com
+  
+## Technique Information
+* Technique title (required): BlockInput
+* Technique category (required): Anti-Debugging
+* Technique description (required): As per Microsoft's documentation, BlockInput function "prevents keyboard and mouse input events from reaching applications," effectively restricting user interaction with the system. Malware occasionally employs this tactic to hinder analysis by debuggers or other analysis tools throughout the process' runtime. To deactivate the block, the program must make a live call to BlockInput with the parameter 0. Windows automatically lifts the block when the process ends or the user initiates Ctrl+Alt+Del.
+
+## Additional resources
+* https://learn.microsoft.com/en-gb/windows/win32/api/winuser/nf-winuser-blockinput
+
+## Code snippets
+* Please add your code in separate files.
+
+## Detection rules
+* Please add your rules in separate files.

--- a/techniques/internet-connectivity-check/internet-connectivity-check.md
+++ b/techniques/internet-connectivity-check/internet-connectivity-check.md
@@ -1,0 +1,21 @@
+# *Internet Connectivity Check*
+
+## Authorship information
+* Name or nickname (required): *Serhii*
+* Twitter: https://twitter.com/semelnyk
+* Linkedin: https://www.linkedin.com/in/serhii-melnyk
+* Email: serhiimelnyk@outlook.com
+  
+## Technique Information
+* Technique title (required): Internet Connectivity Check
+* Technique category (required): Sandbox Evasion
+* Technique description (required): Malware often verifies internet connectivity to distinguish between being within a lab or sandbox environment versus a genuine system. This check allows malware to obscure its behavior from both human analysts and automated sandbox environments. Typically, this involves assessing whether the infected system is online. While many systems used by targeted victims have internet access, lab setups or sandboxes are often isolated from the internet. Typically, API calls necessary for implementing such functionality start with InternetConnectA, or HttpOpenRequestA and HttpSendRequestA, which facilitate the construction and transmission of HTTP requests. For instance, certain functions may return a value of 1 upon detecting a successful connection to a designated destination, and 0 otherwise.
+
+## Additional resources
+* https://sensei-infosec.netlify.app/forensics/windows/api-calls/2020/04/29/win-api-calls-1.html
+
+## Code snippets
+* Please add your code in separate files.
+
+## Detection rules
+* Please add your rules in separate files.

--- a/techniques/stack-strings/stack-strings.md
+++ b/techniques/stack-strings/stack-strings.md
@@ -1,0 +1,23 @@
+# *Stack Strings*
+
+## Authorship information
+* Name or nickname (required): *Serhii*
+* Twitter: https://twitter.com/semelnyk
+* Linkedin: https://www.linkedin.com/in/serhii-melnyk
+* Email: serhiimelnyk@outlook.com
+  
+## Technique Information
+* Technique title (required): Stack Strings
+* Technique category (required): Anti-Disassembly
+* Technique description (required): This approach involves breaking a string into individual characters and dynamically rebuilding it when the program runs. Known as "stack strings," each character of the string is stored in an array, making it difficult for analysts to extract the string's contents using standard tools. This method involves placing each character of the string into consecutive memory locations during runtime using MOV instructions.
+
+## Additional resources
+* https://www.tripwire.com/state-of-security/ghidra-101-decoding-stack-strings
+* https://medium.com/@DCSO_CyTec/hostile-code-dealing-with-stack-strings-in-idapython-7a487b822518
+* https://maxkersten.nl/binary-analysis-course/analysis-scripts/ghidra-script-to-handle-stack-strings/
+
+## Code snippets
+* Please add your code in separate files.
+
+## Detection rules
+* Please add your rules in separate files.


### PR DESCRIPTION
According to Microsoft docs, the BlockInput function "prevents keyboard and mouse input events from reaching applications," effectively limiting user interaction with the system. Malware occasionally utilizes this tactic to impede analysis by debuggers or other analysis tools throughout the process' runtime. To deactivate the block, the program must initiate a live call to BlockInput with the parameter 0. Windows automatically removes the block when the process ends or the user initiates Ctrl+Alt+Del. It's quite basic, but it seems to have been overlooked, so I decided to add it.